### PR TITLE
Only chmod .htpasswd if it has been created

### DIFF
--- a/lib/capistrano/tasks/uberspace.rake
+++ b/lib/capistrano/tasks/uberspace.rake
@@ -128,8 +128,8 @@ AuthName "Restricted"
 AuthUserFile #{File.join(path, '../.htpasswd')}
 Require valid-user
         EOF
+        execute "chmod +r #{path}/../.htpasswd"
       end
-      execute "chmod +r #{path}/../.htpasswd"
 
       htaccess = <<-EOF
 #{basic_auth}


### PR DESCRIPTION
Only chmod file if it has been created, and skip this step if the user hasn't enabled basic auth. Otherwise we get a 'No such file or directory' error.
