### PR TITLE
Puma support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ require 'capistrano/rails/migrations'
 require 'capistrano/uberspace'
 # in the following line replace <database> with mysql, mongoid, postgresql, or sqlite3
 require 'capistrano/uberspace/<database>'
+require 'capistrano/uberspace/<your-server>' # puma / passenger
 ```
 
 Please bundle the appropriate database-gem in your `Gemfile`.
@@ -83,17 +84,32 @@ Configurable options:
 ```ruby
 set :ruby_version, '2.2'  # default is '2.2', can be set to every ruby version supported by uberspace.
 set :domain, nil          # if you want to deploy your app as a subdomain, configure it here. Use the full URI. E.g. my-custom.example.tld
-set :add_www_domain, true # default: true; set this to false if you do not want to also use your subdomain with prefixed www.
+set :add_www_domain, true # default: true; set this to false if you do not want to also use your subdomain with prefixed www.`
+```
 
-# Now you have two options
+### Now you have two options (the first is the prefered one)
+
+Note: You have to create a user by yourself and bind this user to a database. Also a role "dbOwner" is the one which works to create collections and write into it:
+
+#### Example
+
+login to your admin:
+
+    $ mongo admin --port 21111 -u YOURUSERNAME_mongoadmin -p
+
+    # use YOUR_DATABASE
+
+    db.createUser({user: "NEUER_MONGO_USER", password: "SUPERPASSWORT", roles:[{"dbOwner", db: "MEINE_DATENBANK"}]})
+
 
 set :mongo_db, "databaseName"
 set :mongo_host, "localhost"
 set :mongo_user, "your-mongodb-username" # must be created first (Do NOT use the ADMIN)
 set :mongo_password, "your-mongodb-password"
 
-# OR
+or
 
+```
 set :mongo_uri, 'mongodb://user:pass@localhost:PORT/DATABASE_NAME' # DATABASE_NAME could be ENV['APPLICATION']
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ gem 'capistrano', '~> 3.4.0'
 gem 'capistrano-uberspace', github: 'tessi/capistrano-uberspace'
 ```
 
-If you do not install `capistrano-uberspace` in the `production`-group, then add `passenger` as a production dependency:
+If you do not install `capistrano-uberspace` in the `production`-group, then add `passenger` or `puma` as a production dependency:
 
 ```ruby
 gem 'passenger', group: :production
+
+# or
+
+gem 'puma', group: :production
 ```
 
 And then execute:
@@ -44,6 +48,7 @@ server 'your-host.uberspace.de',
        }
 
 set :user, 'uberspace-user'
+set :environment, :production
 set :branch, :production
 set :domain, 'my-subdomain.example.tld'
 ```
@@ -67,9 +72,9 @@ require 'capistrano/rails'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/uberspace'
-# in the following line replace <database> with mysql, mongoid, postgresql, or sqlite3
-require 'capistrano/uberspace/<database>'
-require 'capistrano/uberspace/<your-server>' # puma / passenger
+
+require 'capistrano/uberspace/<database>'  # replace <database> with mysql, mongoid, postgresql, or sqlite3
+require 'capistrano/uberspace/<your-server>' # replace <your-server> with puma or passenger
 ```
 
 Please bundle the appropriate database-gem in your `Gemfile`.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,18 @@ Configurable options:
 set :ruby_version, '2.2'  # default is '2.2', can be set to every ruby version supported by uberspace.
 set :domain, nil          # if you want to deploy your app as a subdomain, configure it here. Use the full URI. E.g. my-custom.example.tld
 set :add_www_domain, true # default: true; set this to false if you do not want to also use your subdomain with prefixed www.
-set :mongo_url, 'mongodb://user:pass@localhost:PORT/DATABASE_NAME' # DATABASE_NAME could be ENV['APPLICATION']
+
+# Now you have two options
+
+set :mongo_db, "databaseName"
+set :mongo_host, "localhost"
+set :mongo_username, "your-mongodb-username" # must be created first (Do NOT use the ADMIN)
+set :mongo_password, "your-mongodb-password"
+
+# OR
+
+set :mongo_uri, 'mongodb://user:pass@localhost:PORT/DATABASE_NAME' # DATABASE_NAME could be ENV['APPLICATION']
+
 ```
 
 Useful tasks:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Deploy your Rails App to [uberspace](http://uberspace.de) with Capistrano 3.
 
-Has support for MySQL, Potsgresql, and sqlite3 databases. Runs your app with any ruby version available at your uberpace.
+Has support for MySQL, Potsgresql, mongoid and sqlite3 databases. Runs your app with any ruby version available at your uberpace.
 
 ## Installation
 
@@ -67,7 +67,7 @@ require 'capistrano/rails'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/uberspace'
-# in the following line replace <database> with mysql, postgresql, or sqlite3
+# in the following line replace <database> with mysql, mongoid, postgresql, or sqlite3
 require 'capistrano/uberspace/<database>'
 ```
 
@@ -84,6 +84,7 @@ Configurable options:
 set :ruby_version, '2.2'  # default is '2.2', can be set to every ruby version supported by uberspace.
 set :domain, nil          # if you want to deploy your app as a subdomain, configure it here. Use the full URI. E.g. my-custom.example.tld
 set :add_www_domain, true # default: true; set this to false if you do not want to also use your subdomain with prefixed www.
+set :mongo_url, 'mongodb://user:pass@localhost:PORT/DATABASE_NAME' # DATABASE_NAME could be ENV['APPLICATION']
 ```
 
 Useful tasks:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ set :add_www_domain, true # default: true; set this to false if you do not want 
 
 set :mongo_db, "databaseName"
 set :mongo_host, "localhost"
-set :mongo_username, "your-mongodb-username" # must be created first (Do NOT use the ADMIN)
+set :mongo_user, "your-mongodb-username" # must be created first (Do NOT use the ADMIN)
 set :mongo_password, "your-mongodb-password"
 
 # OR

--- a/lib/capistrano/tasks/uberspace.rake
+++ b/lib/capistrano/tasks/uberspace.rake
@@ -48,7 +48,7 @@ umask = 077
   task :setup_secrets do
     on roles fetch(:uberspace_roles) do
       secrets = <<-EOF
-#{fetch :passenger_environment}:
+#{fetch :environment}:
   secret_key_base: #{SecureRandom.hex 40}
       EOF
 

--- a/lib/capistrano/tasks/uberspace.rake
+++ b/lib/capistrano/tasks/uberspace.rake
@@ -37,22 +37,6 @@ umask = 077
   end
   after :'uberspace:setup_gemrc', :'uberspace:install_bundler'
 
-  def passenger_port
-    @passenger_port ||= capture(:cat, "#{shared_path}/.passenger-port")
-  end
-
-  task :setup_passenger_port do
-    on roles fetch(:uberspace_roles) do
-      # find free and available port
-      unless test "[ -f #{shared_path}/.passenger-port ]"
-        port = capture('python -c \'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()\'')
-        execute :mkdir, "-p #{shared_path}"
-        upload! StringIO.new(port), "#{shared_path}/.passenger-port"
-      end
-    end
-  end
-  after :'uberspace:check', :'uberspace:setup_passenger_port'
-
   task :setup_svscan do
     on roles fetch(:uberspace_roles) do
       execute 'test -d ~/service || uberspace-setup-svscan; echo 0'
@@ -75,83 +59,6 @@ umask = 077
     end
   end
   after :'uberspace:check', :'uberspace:setup_secrets'
-
-  task :setup_daemon do
-    on roles fetch(:uberspace_roles) do
-      daemon_script = <<-EOF
-#!/bin/bash
-export HOME=#{uberspace_home}
-#{fetch(:uberspace_env_variables).map do |k,v|
-  "export #{k}=#{v}"
-end.join("/n")}
-cd #{fetch :deploy_to}/current
-exec bundle exec passenger start -p #{passenger_port} -e #{fetch :passenger_environment} 2>&1
-      EOF
-
-      log_script = <<-EOF
-#!/bin/sh
-exec multilog t ./main
-      EOF
-
-      execute                 "mkdir -p #{uberspace_home}/etc/run-rails-#{fetch :application}"
-      execute                 "mkdir -p #{uberspace_home}/etc/run-rails-#{fetch :application}/log"
-      upload! StringIO.new(daemon_script), "#{uberspace_home}/etc/run-rails-#{fetch :application}/run"
-      upload! StringIO.new(log_script),    "#{uberspace_home}/etc/run-rails-#{fetch :application}/log/run"
-      execute                 "chmod +x #{uberspace_home}/etc/run-rails-#{fetch :application}/run"
-      execute                 "chmod +x #{uberspace_home}/etc/run-rails-#{fetch :application}/log/run"
-      execute                 "ln -nfs #{uberspace_home}/etc/run-rails-#{fetch :application} #{uberspace_home}/service/rails-#{fetch :application}"
-    end
-  end
-  after :'deploy:updated', :'uberspace:setup_daemon'
-
-  task :setup_apache_reverse_proxy do
-    on roles fetch(:uberspace_roles) do
-      path = fetch(:domain) ? "/var/www/virtual/#{fetch :user}/#{fetch :domain}" : "/var/www/virtual/#{fetch :user}/html"
-      execute "mkdir -p #{path}"
-      basic_auth = ''
-
-      if fetch(:htaccess_username, false)
-        unless fetch(:htaccess_password_hashed, false)
-          password = fetch(:htaccess_password, -> { abort 'ERROR: Define either :htaccess_password or :htaccess_password_hashed'})
-          salt = [*'0'..'9',*'A'..'Z',*'a'..'z'].sample(2).join
-          set :htaccess_password_hashed, "#{password}".crypt(salt)
-        end
-
-        htpasswd = <<-EOF
-#{fetch :htaccess_username}:#{fetch :htaccess_password_hashed}
-        EOF
-        upload! StringIO.new(htpasswd), "#{path}/../.htpasswd"
-
-        basic_auth = <<-EOF
-AuthType Basic
-AuthName "Restricted"
-AuthUserFile #{File.join(path, '../.htpasswd')}
-Require valid-user
-        EOF
-        execute "chmod +r #{path}/../.htpasswd"
-      end
-
-      htaccess = <<-EOF
-#{basic_auth}
-RewriteEngine On
-RewriteBase /
-RewriteRule ^(.*)$ http://localhost:#{passenger_port}/$1 [P]
-      EOF
-
-      upload! StringIO.new(htaccess), "#{path}/.htaccess"
-      execute "chmod +r #{path}/.htaccess"
-
-      if fetch(:domain)
-        execute "uberspace-add-domain -qwd #{fetch :domain} ; true"
-        if fetch(:add_www_domain)
-          wwwpath = "/var/www/virtual/#{fetch :user}/www.#{fetch :domain}"
-          execute "ln -nfs #{path} #{wwwpath}"
-          execute "uberspace-add-domain -qwd www.#{fetch :domain} ; true"
-        end
-      end
-    end
-  end
-  after :'uberspace:check', :'uberspace:setup_apache_reverse_proxy'
 
 end
 

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -7,7 +7,7 @@ namespace :uberspace do
           config[env] = {
               'clients' => {
                   'default' => {
-                      'uri' => fetch(:mongo_url)
+                      'uri' => "#{fetch(:MONGO_URL)}"
                   }
               }
           }
@@ -17,7 +17,9 @@ namespace :uberspace do
         execute "touch #{shared_path}/config/mongoid.yml"
         puts config.inspect
         puts "*"*50
-        puts "deploying to #{shared_path}/config.mongoid.yml"
+        puts "MONGO_URL #{fetch(:MONGO_URL)}"
+        puts "MONGO_URL #{ENV['MONGO_URL']}"
+        puts "deploying to #{shared_path}/config/mongoid.yml"
         upload! StringIO.new(config.to_yaml), "#{shared_path}/config/mongoid.yml"
       end
     end

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -7,7 +7,7 @@ namespace :uberspace do
           config[env] = {
               'clients' => {
                   'default' => {
-                      'uri' => ENV['MONGOID_DATABASE_URL']
+                      'uri' => ENV['MONGO_URL']
                   }
               }
           }

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -4,11 +4,24 @@ namespace :uberspace do
       on roles fetch(:uberspace_roles) do
         config = {}
         stages.each do |env|
+
+          if fetch(:mongo_url, false)
+            default_params = {'default' => {
+                'uri' => "#{fetch(:mongoid_uri)}"
+
+            }}
+          else
+            default_params = {'default' => {
+                'database' => fetch(:application),
+                'hosts' => ["#{fetch(:mongo_host)}:#{fetch(:mongo_port)}"],
+                'password' => fetch(:mongo_password),
+                'username' => fetch(:mongo_username)
+            }}
+          end
+          
           config[env] = {
               'clients' => {
-                  'default' => {
-                      'uri' => "#{fetch(:mongo_url)}"
-                  }
+                  default_params
               }
           }
         end

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -18,7 +18,7 @@ namespace :uberspace do
                 ],
                 'password' => fetch(:mongo_password),
                 'user' => fetch(:mongo_user),
-                'auth_source' => fetch(:application)
+                'auth_source' => "admin"
             }}
           end
 

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -17,7 +17,8 @@ namespace :uberspace do
                     "#{fetch(:mongo_host)}:#{fetch(:mongo_port)}"
                 ],
                 'password' => fetch(:mongo_password),
-                'user' => fetch(:mongo_user)
+                'user' => fetch(:mongo_user),
+                'auth_source' => fetch(:application)
             }}
           end
 

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -16,10 +16,10 @@ namespace :uberspace do
                 'hosts' => [
                     "#{fetch(:mongo_host)}:#{fetch(:mongo_port)}"
                 ],
-                'password' => fetch(:mongo_password),
-                'user' => fetch(:mongo_user),
-                'auth_source' => fetch(:application),
-                'roles' => ['dbOwner']
+                'options' => {'password' => fetch(:mongo_password),
+                              'user' => fetch(:mongo_user),
+                              'auth_source' => fetch(:application),
+                              'roles' => ['dbOwner']}
             }}
           end
 

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -5,7 +5,7 @@ namespace :uberspace do
         config = {}
         stages.each do |env|
 
-          if fetch(:mongo_url, false)
+          if fetch(:mongo_uri, false)
             default_params = {'default' => {
                 'uri' => "#{fetch(:mongoid_uri)}"
 
@@ -13,7 +13,9 @@ namespace :uberspace do
           else
             default_params = {'default' => {
                 'database' => fetch(:application),
-                'hosts' => ["#{fetch(:mongo_host)}:#{fetch(:mongo_port)}"],
+                'hosts' => [
+                    "#{fetch(:mongo_host)}:#{fetch(:mongo_port)}"
+                ],
                 'password' => fetch(:mongo_password),
                 'username' => fetch(:mongo_username)
             }}

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -17,7 +17,7 @@ namespace :uberspace do
                     "#{fetch(:mongo_host)}:#{fetch(:mongo_port)}"
                 ],
                 'password' => fetch(:mongo_password),
-                'username' => fetch(:mongo_username)
+                'user' => fetch(:mongo_user)
             }}
           end
 

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -7,7 +7,7 @@ namespace :uberspace do
           config[env] = {
               'clients' => {
                   'default' => {
-                      'uri' => ENV['MONGO_URL']
+                      'uri' => fetch(:mongo_url)
                   }
               }
           }

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -1,3 +1,5 @@
+require 'inifile'
+
 namespace :uberspace do
   namespace :mongoid do
     task :setup_database_and_config do
@@ -30,10 +32,6 @@ namespace :uberspace do
 
         execute "mkdir -p #{shared_path}/config"
         execute "touch #{shared_path}/config/mongoid.yml"
-        puts config.inspect
-        puts "*"*50
-        puts "MONGO_URL #{fetch(:MONGO_URL)}"
-        puts "APPLICATION #{ENV['APPLICATION']}"
         puts "deploying to #{shared_path}/config/mongoid.yml"
         upload! StringIO.new(config.to_yaml), "#{shared_path}/config/mongoid.yml"
         set :linked_files, fetch(:linked_files, []).push('config/mongoid.yml')

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -18,7 +18,8 @@ namespace :uberspace do
                 ],
                 'password' => fetch(:mongo_password),
                 'user' => fetch(:mongo_user),
-                'auth_source' => "admin"
+                'auth_source' => fetch(:application),
+                'roles' => ['dbOwner']
             }}
           end
 

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -36,6 +36,7 @@ namespace :uberspace do
         puts "APPLICATION #{ENV['APPLICATION']}"
         puts "deploying to #{shared_path}/config/mongoid.yml"
         upload! StringIO.new(config.to_yaml), "#{shared_path}/config/mongoid.yml"
+        set :linked_files, fetch(:linked_files, []).push('config/mongoid.yml')
       end
     end
 

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -18,11 +18,9 @@ namespace :uberspace do
                 'username' => fetch(:mongo_username)
             }}
           end
-          
+
           config[env] = {
-              'clients' => {
-                  default_params
-              }
+              'clients' => default_params
           }
         end
 

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -1,0 +1,27 @@
+namespace :uberspace do
+  namespace :mongoid do
+    task :setup_database_and_config do
+      on roles fetch(:uberspace_roles) do
+        config = {}
+        stages.each do |env|
+          config[env] = {
+              'clients' => {
+                  'default' => {
+                      'uri' => ENV['MONGOID_DATABASE_URL']
+                  }
+              }
+          }
+        end
+
+        execute "mkdir -p #{shared_path}/config"
+        execute "touch #{shared_path}/config/mongoid.yml"
+        puts config.inspect
+        puts "*"*50
+        puts "deploying to #{shared_path}/config.mongoid.yml"
+        upload! StringIO.new(config.to_yaml), "#{shared_path}/config/mongoid.yml"
+      end
+    end
+
+    after :'uberspace:check', :'uberspace:mongoid:setup_database_and_config'
+  end
+end

--- a/lib/capistrano/tasks/uberspace/mongoid.rake
+++ b/lib/capistrano/tasks/uberspace/mongoid.rake
@@ -7,7 +7,7 @@ namespace :uberspace do
           config[env] = {
               'clients' => {
                   'default' => {
-                      'uri' => "#{fetch(:MONGO_URL)}"
+                      'uri' => "#{fetch(:mongo_url)}"
                   }
               }
           }
@@ -18,7 +18,7 @@ namespace :uberspace do
         puts config.inspect
         puts "*"*50
         puts "MONGO_URL #{fetch(:MONGO_URL)}"
-        puts "MONGO_URL #{ENV['MONGO_URL']}"
+        puts "APPLICATION #{ENV['APPLICATION']}"
         puts "deploying to #{shared_path}/config/mongoid.yml"
         upload! StringIO.new(config.to_yaml), "#{shared_path}/config/mongoid.yml"
       end

--- a/lib/capistrano/tasks/uberspace/passenger.rake
+++ b/lib/capistrano/tasks/uberspace/passenger.rake
@@ -1,0 +1,104 @@
+namespace :uberspace do
+
+
+
+  def passenger_port
+    @passenger_port ||= capture(:cat, "#{shared_path}/.passenger-port")
+  end
+
+
+
+  task :setup_passenger_port do
+    on roles fetch(:uberspace_roles) do
+      # find free and available port
+      unless test "[ -f #{shared_path}/.passenger-port ]"
+        port = capture('python -c \'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()\'')
+        execute :mkdir, "-p #{shared_path}"
+        upload! StringIO.new(port), "#{shared_path}/.passenger-port"
+      end
+    end
+  end
+  after :'uberspace:check', :'uberspace:setup_passenger_port'
+
+
+
+  task :setup_daemon do
+    on roles fetch(:uberspace_roles) do
+      daemon_script = <<-EOF
+#!/bin/bash
+export HOME=#{uberspace_home}
+      #{fetch(:uberspace_env_variables).map do |k,v|
+        "export #{k}=#{v}"
+      end.join("/n")}
+cd #{fetch :deploy_to}/current
+exec bundle exec passenger start -p #{passenger_port} -e #{fetch :passenger_environment} 2>&1
+      EOF
+
+      log_script = <<-EOF
+#!/bin/sh
+exec multilog t ./main
+      EOF
+
+      execute                 "mkdir -p #{uberspace_home}/etc/run-rails-#{fetch :application}"
+      execute                 "mkdir -p #{uberspace_home}/etc/run-rails-#{fetch :application}/log"
+      upload! StringIO.new(daemon_script), "#{uberspace_home}/etc/run-rails-#{fetch :application}/run"
+      upload! StringIO.new(log_script),    "#{uberspace_home}/etc/run-rails-#{fetch :application}/log/run"
+      execute                 "chmod +x #{uberspace_home}/etc/run-rails-#{fetch :application}/run"
+      execute                 "chmod +x #{uberspace_home}/etc/run-rails-#{fetch :application}/log/run"
+      execute                 "ln -nfs #{uberspace_home}/etc/run-rails-#{fetch :application} #{uberspace_home}/service/rails-#{fetch :application}"
+    end
+  end
+  after :'deploy:updated', :'uberspace:setup_daemon'
+
+
+
+  task :setup_apache_reverse_proxy do
+    on roles fetch(:uberspace_roles) do
+      path = fetch(:domain) ? "/var/www/virtual/#{fetch :user}/#{fetch :domain}" : "/var/www/virtual/#{fetch :user}/html"
+      execute "mkdir -p #{path}"
+      basic_auth = ''
+
+      if fetch(:htaccess_username, false)
+        unless fetch(:htaccess_password_hashed, false)
+          password = fetch(:htaccess_password, -> { abort 'ERROR: Define either :htaccess_password or :htaccess_password_hashed'})
+          salt = [*'0'..'9',*'A'..'Z',*'a'..'z'].sample(2).join
+          set :htaccess_password_hashed, "#{password}".crypt(salt)
+        end
+
+        htpasswd = <<-EOF
+#{fetch :htaccess_username}:#{fetch :htaccess_password_hashed}
+        EOF
+        upload! StringIO.new(htpasswd), "#{path}/../.htpasswd"
+
+        basic_auth = <<-EOF
+AuthType Basic
+AuthName "Restricted"
+AuthUserFile #{File.join(path, '../.htpasswd')}
+Require valid-user
+        EOF
+        execute "chmod +r #{path}/../.htpasswd"
+      end
+
+      htaccess = <<-EOF
+#{basic_auth}
+RewriteEngine On
+RewriteBase /
+RewriteRule ^(.*)$ http://localhost:#{passenger_port}/$1 [P]
+      EOF
+
+      upload! StringIO.new(htaccess), "#{path}/.htaccess"
+      execute "chmod +r #{path}/.htaccess"
+
+      if fetch(:domain)
+        execute "uberspace-add-domain -qwd #{fetch :domain} ; true"
+        if fetch(:add_www_domain)
+          wwwpath = "/var/www/virtual/#{fetch :user}/www.#{fetch :domain}"
+          execute "ln -nfs #{path} #{wwwpath}"
+          execute "uberspace-add-domain -qwd www.#{fetch :domain} ; true"
+        end
+      end
+    end
+  end
+  after :'uberspace:check', :'uberspace:setup_apache_reverse_proxy'
+
+end

--- a/lib/capistrano/tasks/uberspace/puma.rake
+++ b/lib/capistrano/tasks/uberspace/puma.rake
@@ -10,6 +10,8 @@ namespace :uberspace do
       unless test "[ -f #{shared_path}/.puma-port ]"
         port = capture('python -c \'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()\'')
         execute :mkdir, "-p #{shared_path}"
+        puts '*'*50
+        puts "PORT:#{port}"
         upload! StringIO.new(port), "#{shared_path}/.puma-port"
       end
     end

--- a/lib/capistrano/uberspace/defaults.rb
+++ b/lib/capistrano/uberspace/defaults.rb
@@ -39,7 +39,7 @@ default_env = fetch(:default_env, {})
 set :default_env, -> { default_env.merge(fetch(:uberspace_env_variables)) }
 
 set :linked_dirs,  fetch(:linked_dirs, []).push(*%w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads))
-set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/secrets.yml')
+set :linked_files, fetch(:linked_files, []).push('config/secrets.yml')
 
 # default is "set :bundle_bins, %w{gem rake rails}", but we want to 'gem install bundler' without bundle :)
 set :bundle_bins, %w(rake rails)

--- a/lib/capistrano/uberspace/defaults.rb
+++ b/lib/capistrano/uberspace/defaults.rb
@@ -14,7 +14,7 @@ set :passenger_environment, -> { fetch(:rails_env) || fetch(:stage) }
 set :uberspace_roles, :all
 set :extra_env_variables, fetch(:extra_env_variables) || {}
 
-set :ruby_version, fetch(:ruby_version, '2.2')
+set :ruby_version, fetch(:ruby_version, '2.2.3')
 
 set :gem_path, (lambda do
   begin

--- a/lib/capistrano/uberspace/defaults.rb
+++ b/lib/capistrano/uberspace/defaults.rb
@@ -9,7 +9,7 @@ set :bundle_flags, '--deployment'
 
 set :domain, nil
 set :add_www_domain, -> { !!fetch(:domain) }
-set :passenger_environment, -> { fetch(:rails_env) || fetch(:stage) }
+set :environment, -> { fetch(:rails_env) || fetch(:stage) }
 
 set :uberspace_roles, :all
 set :extra_env_variables, fetch(:extra_env_variables) || {}

--- a/lib/capistrano/uberspace/mongoid.rb
+++ b/lib/capistrano/uberspace/mongoid.rb
@@ -1,0 +1,1 @@
+load File.expand_path('../../tasks/uberspace/mongoid.rake', __FILE__)

--- a/lib/capistrano/uberspace/passenger.rb
+++ b/lib/capistrano/uberspace/passenger.rb
@@ -1,0 +1,1 @@
+load File.expand_path('../../tasks/uberspace/passenger.rake', __FILE__)

--- a/lib/capistrano/uberspace/puma.rb
+++ b/lib/capistrano/uberspace/puma.rb
@@ -1,1 +1,1 @@
-load File.expand_path('../../tasks/uberspace/passenger.rake', __FILE__)
+load File.expand_path('../../tasks/uberspace/puma.rake', __FILE__)

--- a/lib/capistrano/uberspace/puma.rb
+++ b/lib/capistrano/uberspace/puma.rb
@@ -1,0 +1,1 @@
+load File.expand_path('../../tasks/uberspace/passenger.rake', __FILE__)


### PR DESCRIPTION
This adds the possibility to choose puma as production server. 

simply add 

require 'capistrano/uberspace/<your-server>' to Capfile

<your-server> could be "passenger" or "puma"

set an environment

set(:environment, :production)

Done, start deploying, your rails app starts with puma (or passenger).
